### PR TITLE
Test/passgen

### DIFF
--- a/apl/main.go
+++ b/apl/main.go
@@ -199,7 +199,7 @@ func main() {
 				ReuseValues:     true,
 				Timeout:         1200,
 				ValuesFile:      values,
-				Version:         "v4.5.0",
+				Version:         "v4.6.0",
 				WaitForJobs:     false,
 			}
 
@@ -212,33 +212,6 @@ func main() {
 				return err
 			}
 		}
-
-		// new
-		// if step == "4" {
-		// 	pko := "pulumi-kubernetes-operator"
-		// 	pulumiChart := k8s_config.HelmOptions{
-		// 		Chart: pko,
-		// 		CreateNamespace: true,
-		// 		Name:            pko,
-		// 		Namespace:       pko,
-		// 		Repo:            "oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator",
-		// 		Version: "2.0.0",
-		// 	}
-		// 	pulumiOperator, err := k8s_config.NewKubeClusterConfig(ctx, pko, &k8s_config.KubeClusterConfigArgs{
-		// 		ClusterResource: aplcluster,
-		// 		HelmChart:       pulumiChart,
-		// 	}, pulumi.Provider(linodeProvider), pulumi.DependsOn([]pulumi.Resource{aplcluster}))
-		// 	if err != nil {
-		// 		return err
-		// 	}
-		// 	_, err := yaml.NewConfigFile(ctx, "pulumi-service-account", &yaml.ConfigFileArgs{
-		//         File: "./apl/k8s_config/manifests/pulumi-service-account.yaml",
-		//     },)
-		// 	if err != nil {
-		//     	return err
-		// 	}
-		// end new
-		// }
 		return nil
 	})
 }

--- a/setup.sh
+++ b/setup.sh
@@ -111,7 +111,7 @@ random_pass() {
   # Generate random password that meets Keycloak requirements
   p=$(uuidgen | md5sum | base64)
   pass=$(echo $p | fold -w1 | shuf | tr -d '\n')
-  echo -e $pass
+  echo -ne $pass
 }
 
 linode_setup() {
@@ -125,7 +125,10 @@ linode_setup() {
     --header 'accept: application/json' \
     --header "authorization: Bearer $LINODE_TOKEN" \
     --header 'content-type: application/json' \
-    --data '{ "label": "apl-demo-key" }' | jq -r .label,.access_key,.secret_key))
+    --data '{ "label": "apl-demo-key" }' | jq -r .access_key,.secret_key))
+  
+  obj_access_key=$(echo -ne "${obj[0]}" | tr -d '\n')
+  obj_secret_key=$(echo -ne "${obj[1]}" | tr -d '\n')
 }
 
 pulumi_setup() {
@@ -149,8 +152,8 @@ pulumi_setup() {
   msg login && pulumi login
   msg env $stack && esc env init $stack
   msg set linode.token && esc env set $stack linode.token $LINODE_TOKEN --secret
-  msg set linode.objAccessKey && esc env set $stack linode.objAccessKey "${obj[1]}"
-  msg set linode.objSecretKey && esc env set $stack linode.objSecretKey "${obj[2]}" --secret
+  msg set linode.objAccessKey && esc env set $stack linode.objAccessKey $obj_access_key
+  msg set linode.objSecretKey && esc env set $stack linode.objSecretKey $obj_secret_key --secret
   msg set apl.age.publicKey && esc env set $stack apl.age.publicKey $age_public_key
   msg set apl.age.privateKey && esc env set $stack apl.age.privateKey $age_secret_key --secret
 
@@ -189,8 +192,8 @@ age_setup() {
 
   msg age
   keypair=$(age-keygen 2> /dev/null)
-  age_public_key=$(echo $keypair | awk -F ' ' '{print $7}')
-  age_secret_key=$(echo $keypair | awk -F ' ' '{print $8}')
+  age_public_key=$(echo -ne $keypair | awk -F ' ' '{print $7}' | tr -d '\n')
+  age_secret_key=$(echo -ne $keypair | awk -F ' ' '{print $8}' | tr -d '\n')
 }
 
 # main


### PR DESCRIPTION
Modified passgen to alphanumeric strings to troubleshoot APL install issue. New format both works and matches the default passgen style of the APL Helm chart. Also cleaned up apl/main.go file changes.